### PR TITLE
Handle facts when shorewall not installed

### DIFF
--- a/lib/facter/shorewall_major_version.rb
+++ b/lib/facter/shorewall_major_version.rb
@@ -1,5 +1,6 @@
 Facter.add("shorewall_major_version") do
   setcode do
-    Facter::Util::Resolution.exec('shorewall version').split('.').first || nil
+    ver = Facter::Util::Resolution.exec('shorewall version')
+    (ver.nil?) ? nil : ver.split('.').first
   end
 end


### PR DESCRIPTION
If the facts are ran on a system without shorewall installed it causes an error.